### PR TITLE
The response headers are now case insensitive

### DIFF
--- a/swaggerconformance/response.py
+++ b/swaggerconformance/response.py
@@ -9,6 +9,11 @@ __all__ = ["Response"]
 log = logging.getLogger(__name__)
 
 
+class CaseInsensitiveDict(dict):
+    def __getitem__(self, key):
+        return {k.lower(): v for k, v in self.items()}[key.lower()]
+
+
 class Response:
     """A response received to a Swagger API operation.
 
@@ -46,6 +51,8 @@ class Response:
 
         Example format is ``{'Content-Type': [xxx, xxx]}``
 
+        Header field names are case insensitive (See http://www.ietf.org/rfc/rfc2616.txt)
+
         :rtype: dict(str, list(str))
         """
-        return self._raw_response.header
+        return CaseInsensitiveDict(self._raw_response.header)

--- a/tests/test_swaggerconformance.py
+++ b/tests/test_swaggerconformance.py
@@ -9,6 +9,7 @@ the constraints of the schema in these tests - the `pyswagger` module used to
 drive the API does all the validation of input required for us.
 """
 import unittest
+import unittest.mock
 import re
 import os.path as osp
 import json
@@ -18,6 +19,7 @@ import responses
 import hypothesis
 
 import swaggerconformance
+import swaggerconformance.response
 
 
 TEST_SCHEMA_DIR = osp.relpath(osp.join(osp.dirname(osp.realpath(__file__)),
@@ -379,6 +381,23 @@ class MultiRequestTestCase(unittest.TestCase):
                 "{!r} != {!r}".format(out_data, in_data)
 
         single_operation_test(client, put_operation, get_operation) # pylint: disable=E1120
+
+
+class ResponseTestCase(unittest.TestCase):
+    """Test the Response class."""
+
+    def test_insensitive_headers(self):
+        """
+        Verify that headers are case insensitive (See http://www.ietf.org/rfc/rfc2616.txt)...
+
+             'Each header field consists of a name followed by a colon (":") and the field value.
+              Field names are case-insensitive.'
+        """
+        raw_response = unittest.mock.Mock()
+        content_type = 'application/json'
+        raw_response.header = {'content-type': [content_type]}
+        response = swaggerconformance.response.Response(raw_response)
+        assert response.headers['CoNTenT-tyPe'] == [content_type]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
According to See http://www.ietf.org/rfc/rfc2616.txt the header field names are case insensitive, however swagger conformance assumes that the case "Content-Type" is used. This PR fixes it so that header keys are case insensitive.